### PR TITLE
Make TLS Fingerprint Type value an enum instead of string

### DIFF
--- a/src/cat_claims.rs
+++ b/src/cat_claims.rs
@@ -159,11 +159,11 @@ pub mod keys {
 /// Helper functions for creating CATTPRINT (Common Access Token TLS Fingerprint) claims
 pub mod cattprint {
     use super::*;
-    use crate::constants::{tprint_params};
+    use crate::{constants::tprint_params, FingerprintType};
 
-    pub fn create(fingerprint_type: &str, fingerprint_value: &str) -> CborValue {
+    pub fn create(fingerprint_type: FingerprintType, fingerprint_value: &str) -> CborValue {
         let mut params = BTreeMap::new();
-        params.insert(tprint_params::FINGERPRINT_TYPE, CborValue::Text(fingerprint_type.to_string()));
+        params.insert(tprint_params::FINGERPRINT_TYPE, CborValue::Integer(fingerprint_type as i64));
         params.insert(tprint_params::FINGERPRINT_VALUE, CborValue::Text(fingerprint_value.to_string()));
         CborValue::Map(params)
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -131,30 +131,80 @@ pub mod tprint_params {
     pub const FINGERPRINT_VALUE: i32 = 1;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)] // Use u8 as it's efficient for < 256 variants
+pub enum FingerprintType {
+    JA3 = 0,
+    JA3S = 1,
+    JA4 = 2,
+    JA4S = 3,
+    JA4H = 4,
+    JA4L = 5,
+    JA4X = 6,
+    JA4SSH = 7,
+    JA4T = 8,
+    JA4TS = 9,
+    JA4TSCAN = 10,
+    JA4D = 11,
+    JA4D6 = 12,
+}
+
+impl FingerprintType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FingerprintType::JA3 => "JA3",
+            FingerprintType::JA3S => "JA3S",
+            FingerprintType::JA4 => "JA4",
+            FingerprintType::JA4S => "JA4S",
+            FingerprintType::JA4H => "JA4H",
+            FingerprintType::JA4L => "JA4L",
+            FingerprintType::JA4X => "JA4X",
+            FingerprintType::JA4SSH => "JA4SSH",
+            FingerprintType::JA4T => "JA4T",
+            FingerprintType::JA4TS => "JA4TS",
+            FingerprintType::JA4TSCAN => "JA4TScan", 
+            FingerprintType::JA4D => "JA4D",
+            FingerprintType::JA4D6 => "JA4D6",
+        }
+    }
+}
+
+impl std::fmt::Display for FingerprintType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 // Values for Fingerprint Types for CATTPRINT claims
 // Possible fingerprint-type values: JA3, JA4, JA4S, JA4H, JA4L, JA4X, JA4SSH, JA4T, JA4TS, JA4TScan
-pub mod tprint_type_values {
-    // JA3
-    pub const JA3: &str = "JA3";
-    // JA4
-    pub const JA4: &str = "JA4";
-    // JA4S
-    pub const JA4S: &str = "JA4S";
-    // JA4H
-    pub const JA4H: &str = "JA4H";
-    // JA4L
-    pub const JA4L: &str = "JA4L";
-    // JA4X
-    pub const JA4X: &str = "JA4X";
-    // JA4SSH
-    pub const JA4SSH: &str = "JA4SSH";
-    // JA4T
-    pub const JA4T: &str = "JA4T";
-    // JA4TS
-    pub const JA4TS: &str = "JA4TS";
-    // JA4TScan
-    pub const JA4TSCAN: &str = "JA4TScan";
-}
+// pub mod tprint_type_values {
+//     // JA3
+//     pub const JA3: &str = "JA3";
+//     // JA3S
+//     pub const JA3S: &str = "JA3S";
+//     // JA4
+//     pub const JA4: &str = "JA4";
+//     // JA4S
+//     pub const JA4S: &str = "JA4S";
+//     // JA4H
+//     pub const JA4H: &str = "JA4H";
+//     // JA4L
+//     pub const JA4L: &str = "JA4L";
+//     // JA4X
+//     pub const JA4X: &str = "JA4X";
+//     // JA4SSH
+//     pub const JA4SSH: &str = "JA4SSH";
+//     // JA4T
+//     pub const JA4T: &str = "JA4T";
+//     // JA4TS
+//     pub const JA4TS: &str = "JA4TS";
+//     // JA4TScan
+//     pub const JA4TSCAN: &str = "JA4TScan";
+//     // JA4D
+//     pub const JA4D: &str = "JA4D";
+//     // JA4D6
+//     pub const JA4D6: &str = "JA4D6";
+// }
 
 /// CWT claim keys as defined in RFC 8392
 pub mod cwt_keys {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use cat_claims::{
 pub use claims::{Claims, RegisteredClaims};
 pub use constants::{
     cat_keys, cose_algs, cose_labels, cwt_keys, match_types, renewal_params, renewal_types,
-    replay_values, uri_components, tprint_params, tprint_type_values
+    replay_values, uri_components, tprint_params, FingerprintType
 };
 pub use error::Error;
 pub use header::{Algorithm, CborValue, Header, HeaderMap, KeyId};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{
     cat_keys, catm, catr, catreplay, catu, cattprint,
     claims::RegisteredClaims,
-    constants::{uri_components, tprint_type_values},
+    constants::{uri_components, FingerprintType},
     header::{Algorithm, CborValue, KeyId},
     token::{Token, TokenBuilder, VerificationOptions},
     utils::current_timestamp,
@@ -1046,7 +1046,7 @@ fn test_catu_stem_with_multiple_dots() {
 #[test]
 fn test_cattprint_token() {
     let key = b"test-key-for-hmac-sha256-algorithm";
-    let test_fingerprint_type = tprint_type_values::JA4;
+    let test_fingerprint_type = FingerprintType::JA4;
     let test_fingerprint_value = "t13d1516h2_8daaf6152771_b186095e22b6";
 
     // Create a token with CATTPRINT claim
@@ -1066,8 +1066,8 @@ fn test_cattprint_token() {
         use crate::constants::{tprint_params};
 
         // Check fingerprint type
-        if let Some(CborValue::Text(fingerprint_type)) = cattprint_map.get(&tprint_params::FINGERPRINT_TYPE) {
-            assert_eq!(*fingerprint_type, test_fingerprint_type);
+        if let Some(CborValue::Integer(fingerprint_type)) = cattprint_map.get(&tprint_params::FINGERPRINT_TYPE) {
+            assert_eq!(*fingerprint_type, test_fingerprint_type as i64);
         } else {
             panic!("Missing or invalid fingerprint type");
         }


### PR DESCRIPTION
Instead of a string, represent the Fingerprint Type as an enum.

Initial enum values
```
pub enum FingerprintType {
    JA3 = 0,
    JA3S = 1,
    JA4 = 2,
    JA4S = 3,
    JA4H = 4,
    JA4L = 5,
    JA4X = 6,
    JA4SSH = 7,
    JA4T = 8,
    JA4TS = 9,
    JA4TSCAN = 10,
    JA4D = 11,
    JA4D6 = 12,
}
```