### PR TITLE
Add Common Access Token benchmarks with report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Cargo.lock
 target
 .vscode
+.venv
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,11 @@ rsa = { version = "0.9", features = ["sha2"] }
 sha2 = "0.10"
 # RNG for PSS salt generation (WASM-friendly via getrandom)
 rand_core = { version = "0.6", features = ["getrandom"] }
+
+[dev-dependencies]
+# Statistical benchmarking harness (`cargo bench`).
+criterion = "0.5"
+
+[[bench]]
+name = "cat"
+harness = false

--- a/README.md
+++ b/README.md
@@ -409,6 +409,53 @@ See the `examples` directory for complete usage examples:
 - `cat_validation.rs`: Shows how to validate CAT-specific claims
 - `extended_cat_claims.rs`: Comprehensive examples of all CAT claims including CATPOR, CATNIP, CATALPN, CATH, CATGEO*, CATTPK, CATDPOP, CATIF
 
+## Benchmarks
+
+The crate ships [Criterion](https://github.com/bheisler/criterion.rs) benchmarks
+measuring **signing time**, **verification time**, and **signature/token size**
+for every supported algorithm (HS256, ES256, PS256).
+
+Run them the native Rust way:
+
+```bash
+cargo bench --bench cat
+```
+
+To produce a shareable report with graphs, run the benchmarks and then the
+report generator. The markdown report and SVG charts need no third-party Python
+packages:
+
+```bash
+cargo bench --bench cat
+python3 scripts/bench_report.py          # add --pdf to also render a PDF
+# or do both at once:
+scripts/run_benchmarks.sh                # --quick for a fast run, --pdf for a PDF
+```
+
+Outputs are written to `target/bench/`:
+
+- `report.md` — markdown summary table, graphs, and notes
+- `report.pdf` — printable PDF (only with `--pdf`)
+- `signing_time.svg`, `verification_time.svg`, `signature_size.svg`, `token_size.svg`
+
+The PDF is rendered with [`fpdf2`](https://pypi.org/project/fpdf2/), a pure-Python
+package with no native dependencies and no browser. Without `--pdf`, `fpdf2` is
+not needed at all.
+
+`scripts/run_benchmarks.sh --pdf` bootstraps a local virtualenv at `.venv` and
+installs `fpdf2` into it automatically (Homebrew's system Python is externally
+managed, so it can't be installed into directly). In CI, where Python isn't
+externally managed, you can skip the venv and just `pip3 install fpdf2` before
+running `python3 scripts/bench_report.py --pdf`.
+
+Indicative results (Apple Silicon, release build — your numbers will vary):
+
+| Algorithm | Signing time | Verification time | Signature size | Token size |
+| --------- | -----------: | ----------------: | -------------: | ---------: |
+| HS256 | ~1.8 µs | ~3.4 µs | 32 B | 150 B |
+| ES256 | ~350 µs | ~220 µs | 64 B | 182 B |
+| PS256 | ~1.16 ms | ~140 µs | 256 B | 376 B |
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/benches/cat.rs
+++ b/benches/cat.rs
@@ -1,0 +1,171 @@
+//! Criterion benchmarks for Common Access Token signing and verification.
+//!
+//! Covers every supported algorithm — HS256 (HMAC-SHA256), ES256 (ECDSA
+//! P-256), and PS256 (RSASSA-PSS) — and measures:
+//!
+//!   * **Signing time**      — building the COSE structure and producing the tag/signature.
+//!   * **Verification time** — verifying the tag/signature on an already-decoded token.
+//!   * **Signature size**    — the raw tag/signature length, plus the full encoded token size.
+//!
+//! Timing data is collected by Criterion (`target/criterion/...`). The size
+//! data — which Criterion has no notion of — is written to
+//! `target/bench/sizes.json` so the report generator can combine both into a
+//! single markdown report with graphs.
+//!
+//! Run with:  `cargo bench --bench cat`
+//! Then build a report with: `python3 scripts/bench_report.py`
+
+use std::fs;
+use std::path::Path;
+
+use common_access_token::{
+    current_timestamp, Algorithm, KeyId, RegisteredClaims, Token, TokenBuilder, VerificationOptions,
+};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use ct_codecs::{Base64, Decoder};
+
+// ⚠️ DEMO KEYS — DO NOT USE IN PRODUCTION.
+// Identical throwaway key material to `examples/asymmetric_signing.rs`; these
+// are publicly committed and exist only so the benchmark is self-contained.
+const ES256_PRIVATE_KEY_B64: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg7BOlgwBOMKscTUCaG3RmlSCgUznDdxMn+9Pvoqp4pUOhRANCAARWMcvR3DnF1U15IvgcOyAxr3pJPfOHcF7ESuY+H+ya3LCH03PC1d99/XgN1ldF+wmMxVhY0w9iop10N6tNZDTg";
+const ES256_PUBLIC_KEY_B64: &str = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVjHL0dw5xdVNeSL4HDsgMa96ST3zh3BexErmPh/smtywh9NzwtXfff14DdZXRfsJjMVYWNMPYqKddDerTWQ04A==";
+
+const PS256_PRIVATE_KEY_B64: &str = "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCHjA5iauwvo2sRB529iV1c+p+WuGFzk5EUGFFLYoIHxAwo/rSmZ2/D00epwb4WzOxA4c8+1QA+0rZIN35Fti9Wiunt0b1DgC0tuSglNzpEE5gjhTDcAWZOBPOCMt9pKEuuQC4eqBRxPoG5Y14dVi46/aQOQSqU5I0T3cbeLliTzjXkrvdqySFXMGpM9/I469SZRxZbDgB8wUcB2nTIuwOokjN/Vp+BpMM5QmR66J6aFNi8LqCmQv3grUI1kM1fqrC3az/YcyXcDvjinagyXsGYgW2ZpXIf2760UXv/bASAOO01sgI8zxbIDdG6Vd+7iPhr4b/v6QIj6rpuURFfns2LAgMBAAECggEAH9CdXbdYCZRzYHNnsGGqEtVWmQNdCEo2Lr/IcQfFmnoHGqYyE67Kmm2gb/VkHyjpOQ9nXAmVvakqlMfFsSoicU84uhPVNx9CO22uwRF18R2iQ5ATGEiR0TUzTLeRHbcSEGvLB3IPHkd8Hl327K7aOglntNrR2lHM1UFkWKkLLGHObPoLBSTQLjX5JkvtpUuBgnPVlfBUc5al9+CH+m/SiC4BvVWo4hiHEKCQgMIQ/Dh8UtS9Vk91FIizqKpqBXE6+PNmAnn9ZwRjZoRNBSLn0paAyiEXXdr5rV8zeYU0ktY40J9qWEFOJmTYII4pUK1U8tukrQ0w4LUm17f8zMkufQKBgQC7MGcSrbFWVjlEwA760sG6NKOZb5sL+2etIVAJyfSoGrwr8H4aQA1WFP+pmmlCWsLZj8qfTYSyocwfT/p9aY9Na7ftyks+q1QSsDF+D7frgxmITJeCSwiPa7jnOTrmReqAEOyPn8IlytHIhJbaPxzDxPf572QIAIBgsWhdygn21QKBgQC5X9agS0u2Joypz36ZIilbgbtgmSvFAE/22U0il+3GgXQbjmxPCip1UZm1cBgmLhq12bxU1xYxJpGVPWhEsmkIrOkEfNf/RYlSvVLzbuZLQxeB1g5FDrFb1EbaegrFznv/rFonyXMeRyJ7PHtDttfN5jxNTxTiV3BQ4uobgsai3wKBgFEiW6q26mSXnt7zuApzi1CgPEDnJPb+kyNxivWTOZ4baHBLHv1VwfILy/zBVtpR6J7QOmzt9pROmOEBk3sEY/6Ur/Y7dn3FWP14rRsMyRUlj82KFSl+SEmR0WU3YxYoO8oii8Z84nPrAx68iX4zWM5p82m7n0nwnbRLcQcl6Ue5AoGACjVN42viEnjS/DLx/MrVzjU5tVsZ/vJCdQyIY+RL8seENlREgKHFrso8lbJDki6tx9/isCVcEn7WO4qzKD1O7WxgNKAPYP5aTpUgcUllIzXhoIPCK2lguPbapANefoAdcfnyyQgd78fpDTJKc3MpNSx9m6BEPSalh77HN5afC68CgYBSHR2vz1GuUzHSgU+3xKqGSc+jlroetJ1dC5913Z+9eawW7QrRfmSod+JfEiJSw8eS+5/rGYjKihMtNPyqzadRvZtp0QGZrrm1k1/vqqeeH5Uq6AgH/2Djql4tUvC3gmgpHjY7RyPDv6v+u+L9C6MP0Nu5vVfQwpAmX9bsjn/Tjw==";
+const PS256_PUBLIC_KEY_B64: &str = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh4wOYmrsL6NrEQedvYldXPqflrhhc5ORFBhRS2KCB8QMKP60pmdvw9NHqcG+FszsQOHPPtUAPtK2SDd+RbYvVorp7dG9Q4AtLbkoJTc6RBOYI4Uw3AFmTgTzgjLfaShLrkAuHqgUcT6BuWNeHVYuOv2kDkEqlOSNE93G3i5Yk8415K73askhVzBqTPfyOOvUmUcWWw4AfMFHAdp0yLsDqJIzf1afgaTDOUJkeuiemhTYvC6gpkL94K1CNZDNX6qwt2s/2HMl3A744p2oMl7BmIFtmaVyH9u+tFF7/2wEgDjtNbICPM8WyA3RulXfu4j4a+G/7+kCI+q6blERX57NiwIDAQAB";
+
+/// HMAC shared secret for HS256.
+const HS256_SECRET: &[u8] = b"benchmark-secret-key-for-hmac-sha256";
+
+/// One algorithm under test, with its signing and verifying key material.
+struct AlgCase {
+    /// Stable identifier used both as the Criterion benchmark id and the JSON key.
+    id: &'static str,
+    algorithm: Algorithm,
+    /// Key passed to `sign` (HMAC secret, or PKCS#8 DER private key).
+    signing_key: Vec<u8>,
+    /// Key passed to `verify` (same HMAC secret, or SPKI DER public key).
+    verifying_key: Vec<u8>,
+}
+
+/// Build the set of algorithms to benchmark.
+fn alg_cases() -> Vec<AlgCase> {
+    let es_priv = Base64::decode_to_vec(ES256_PRIVATE_KEY_B64, None).expect("valid ES256 private");
+    let es_pub = Base64::decode_to_vec(ES256_PUBLIC_KEY_B64, None).expect("valid ES256 public");
+    let ps_priv = Base64::decode_to_vec(PS256_PRIVATE_KEY_B64, None).expect("valid PS256 private");
+    let ps_pub = Base64::decode_to_vec(PS256_PUBLIC_KEY_B64, None).expect("valid PS256 public");
+
+    vec![
+        AlgCase {
+            id: "HS256",
+            algorithm: Algorithm::HmacSha256,
+            signing_key: HS256_SECRET.to_vec(),
+            verifying_key: HS256_SECRET.to_vec(),
+        },
+        AlgCase {
+            id: "ES256",
+            algorithm: Algorithm::Es256,
+            signing_key: es_priv,
+            verifying_key: es_pub,
+        },
+        AlgCase {
+            id: "PS256",
+            algorithm: Algorithm::Ps256,
+            signing_key: ps_priv,
+            verifying_key: ps_pub,
+        },
+    ]
+}
+
+/// A representative CAT builder shared across signing benchmarks so every
+/// algorithm signs an identically-shaped payload.
+fn sample_builder(algorithm: Algorithm) -> TokenBuilder {
+    let now = current_timestamp();
+    TokenBuilder::new()
+        .algorithm(algorithm)
+        .protected_key_id(KeyId::string("bench-key-1"))
+        .registered_claims(
+            RegisteredClaims::new()
+                .with_issuer("example-issuer")
+                .with_subject("example-subject")
+                .with_audience("example-audience")
+                .with_expiration(now + 3600)
+                .with_not_before(now)
+                .with_issued_at(now),
+        )
+        .custom_string(100, "custom-string-value")
+}
+
+fn bench_sign(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sign");
+    for case in alg_cases() {
+        group.bench_function(case.id, |b| {
+            b.iter_batched(
+                || sample_builder(case.algorithm),
+                |builder| builder.sign(&case.signing_key).expect("sign"),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("verify");
+    for case in alg_cases() {
+        // Pre-sign and decode once; the benchmark measures only signature/tag
+        // verification, not CBOR decoding.
+        let token = sample_builder(case.algorithm)
+            .sign(&case.signing_key)
+            .expect("sign");
+        let bytes = token.to_bytes().expect("encode");
+        let decoded = Token::from_bytes(&bytes).expect("decode");
+
+        // Sanity check before timing so a broken setup fails loudly.
+        decoded.verify(&case.verifying_key).expect("verify");
+
+        group.bench_function(case.id, |b| {
+            b.iter(|| decoded.verify(&case.verifying_key).expect("verify"));
+        });
+    }
+    group.finish();
+
+    // Emit size data alongside the timing benchmarks so the report generator
+    // has everything it needs from a single `cargo bench` run.
+    write_sizes();
+}
+
+/// Measure signature and token sizes for each algorithm and write them to
+/// `target/bench/sizes.json` for the report generator to consume.
+fn write_sizes() {
+    let mut entries = Vec::new();
+    for case in alg_cases() {
+        let token = sample_builder(case.algorithm)
+            .sign(&case.signing_key)
+            .expect("sign");
+        let token_bytes = token.to_bytes().expect("encode");
+
+        // Verify claims too, just to confirm the sized token is fully valid.
+        let options = VerificationOptions::new()
+            .verify_exp(true)
+            .verify_nbf(true)
+            .expected_issuer("example-issuer")
+            .expected_audience("example-audience");
+        token.verify_claims(&options).expect("claims valid");
+
+        entries.push(format!(
+            "    {{\n      \"algorithm\": \"{}\",\n      \"signature_bytes\": {},\n      \"token_bytes\": {}\n    }}",
+            case.id,
+            token.signature.len(),
+            token_bytes.len()
+        ));
+    }
+
+    let json = format!("{{\n  \"sizes\": [\n{}\n  ]\n}}\n", entries.join(",\n"));
+
+    let dir = Path::new("target/bench");
+    fs::create_dir_all(dir).expect("create target/bench");
+    fs::write(dir.join("sizes.json"), json).expect("write sizes.json");
+}
+
+criterion_group!(benches, bench_sign, bench_verify);
+criterion_main!(benches);

--- a/scripts/bench_report.py
+++ b/scripts/bench_report.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Generate a markdown report and SVG graphs from CAT benchmark results.
+
+Reads the timing data Criterion writes under ``target/criterion`` and the
+signature/token size data ``benches/cat.rs`` writes to
+``target/bench/sizes.json``, then produces:
+
+    target/bench/report.md          — a shareable markdown report
+    target/bench/signing_time.svg   — signing time per algorithm (bar chart)
+    target/bench/verification_time.svg
+    target/bench/signature_size.svg
+    target/bench/token_size.svg
+
+The markdown report and SVG charts have **no third-party dependencies** — they
+run on a stock Python 3 install and the SVGs render inline on GitHub.
+
+With ``--pdf`` it also renders ``target/bench/report.pdf``. This is the only
+feature that needs a package: ``fpdf2`` (pure Python, no native libs), so the
+PDF path works in CI with a plain ``pip3 install fpdf2`` and no browser.
+
+Usage:
+    cargo bench --bench cat      # produce the raw data first
+    python3 scripts/bench_report.py [--pdf]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Algorithms in the order we want them displayed.
+ALGORITHMS = ["HS256", "ES256", "PS256"]
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CRITERION_DIR = os.path.join(ROOT, "target", "criterion")
+SIZES_PATH = os.path.join(ROOT, "target", "bench", "sizes.json")
+OUT_DIR = os.path.join(ROOT, "target", "bench")
+
+
+def read_timing(group: str, alg: str) -> dict | None:
+    """Return timing stats (in nanoseconds) for one Criterion benchmark.
+
+    Criterion stores the latest run under ``<group>/<alg>/new/estimates.json``.
+    Returns ``None`` if that benchmark hasn't been run yet.
+    """
+    path = os.path.join(CRITERION_DIR, group, alg, "new", "estimates.json")
+    if not os.path.isfile(path):
+        return None
+    with open(path) as fh:
+        data = json.load(fh)
+    return {
+        "mean_ns": data["mean"]["point_estimate"],
+        "median_ns": data["median"]["point_estimate"],
+        "stderr_ns": data["mean"]["standard_error"],
+    }
+
+
+def read_sizes() -> dict[str, dict]:
+    """Return ``{alg: {signature_bytes, token_bytes}}`` from sizes.json."""
+    if not os.path.isfile(SIZES_PATH):
+        return {}
+    with open(SIZES_PATH) as fh:
+        data = json.load(fh)
+    return {e["algorithm"]: e for e in data.get("sizes", [])}
+
+
+def fmt_time(ns: float) -> str:
+    """Human-friendly duration from a nanosecond value."""
+    if ns < 1_000:
+        return f"{ns:.1f} ns"
+    if ns < 1_000_000:
+        return f"{ns / 1_000:.2f} µs"
+    return f"{ns / 1_000_000:.3f} ms"
+
+
+# --- SVG bar chart -----------------------------------------------------------
+
+# Distinct fill per algorithm so charts are readable in the report.
+BAR_COLORS = {
+    "HS256": "#4e79a7",
+    "ES256": "#59a14f",
+    "PS256": "#e15759",
+}
+
+
+def svg_bar_chart(title: str, unit: str, values: list[tuple[str, float, str]]) -> str:
+    """Render a horizontal bar chart as a standalone SVG string.
+
+    ``values`` is a list of ``(label, numeric_value, display_text)`` tuples.
+    Bars are scaled to the largest value so relative magnitudes are obvious
+    even across algorithms that differ by orders of magnitude.
+    """
+    width = 720
+    row_h = 46
+    top_pad = 56
+    bottom_pad = 24
+    left_pad = 80
+    right_pad = 180
+    height = top_pad + row_h * len(values) + bottom_pad
+    max_val = max((v for _, v, _ in values), default=1.0) or 1.0
+    bar_max = width - left_pad - right_pad
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" font-family="-apple-system, Segoe UI, Helvetica, Arial, sans-serif">',
+        f'<rect width="{width}" height="{height}" fill="#ffffff"/>',
+        f'<text x="{width / 2:.0f}" y="30" text-anchor="middle" font-size="18" '
+        f'font-weight="600" fill="#222">{title}</text>',
+        f'<text x="{width / 2:.0f}" y="48" text-anchor="middle" font-size="12" '
+        f'fill="#777">lower is better — {unit}</text>',
+    ]
+
+    for i, (label, value, display) in enumerate(values):
+        y = top_pad + i * row_h + 8
+        bar_w = max(2.0, bar_max * (value / max_val))
+        color = BAR_COLORS.get(label, "#888888")
+        parts.append(
+            f'<text x="{left_pad - 10}" y="{y + 20}" text-anchor="end" '
+            f'font-size="14" font-weight="600" fill="#333">{label}</text>'
+        )
+        parts.append(
+            f'<rect x="{left_pad}" y="{y}" width="{bar_w:.1f}" height="28" '
+            f'rx="3" fill="{color}"/>'
+        )
+        parts.append(
+            f'<text x="{left_pad + bar_w + 8:.1f}" y="{y + 20}" '
+            f'font-size="13" fill="#333">{display}</text>'
+        )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def write(path: str, content: str) -> None:
+    with open(path, "w") as fh:
+        fh.write(content)
+    print(f"wrote {os.path.relpath(path, ROOT)}")
+
+
+def main() -> int:
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    sizes = read_sizes()
+    sign = {a: read_timing("sign", a) for a in ALGORITHMS}
+    verify = {a: read_timing("verify", a) for a in ALGORITHMS}
+
+    have_timing = any(sign.values()) or any(verify.values())
+    if not have_timing and not sizes:
+        print(
+            "No benchmark data found. Run `cargo bench --bench cat` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- charts --------------------------------------------------------------
+    # Build the chart data once (title, unit, and (label, value, display) rows)
+    # so the same numbers drive both the SVG files and the PDF — no rendering
+    # engine needed, since we draw the bars ourselves.
+    charts: dict[str, dict] = {}
+
+    if any(sign.values()):
+        charts["signing_time"] = {
+            "title": "CAT Signing Time",
+            "unit": "mean per signature",
+            "rows": [
+                (a, sign[a]["mean_ns"], fmt_time(sign[a]["mean_ns"]))
+                for a in ALGORITHMS
+                if sign[a]
+            ],
+        }
+
+    if any(verify.values()):
+        charts["verification_time"] = {
+            "title": "CAT Verification Time",
+            "unit": "mean per verification",
+            "rows": [
+                (a, verify[a]["mean_ns"], fmt_time(verify[a]["mean_ns"]))
+                for a in ALGORITHMS
+                if verify[a]
+            ],
+        }
+
+    if sizes:
+        charts["signature_size"] = {
+            "title": "CAT Signature Size",
+            "unit": "raw signature/tag",
+            "rows": [
+                (a, sizes[a]["signature_bytes"], f'{sizes[a]["signature_bytes"]} bytes')
+                for a in ALGORITHMS
+                if a in sizes
+            ],
+        }
+        charts["token_size"] = {
+            "title": "CAT Encoded Token Size",
+            "unit": "full CBOR token",
+            "rows": [
+                (a, sizes[a]["token_bytes"], f'{sizes[a]["token_bytes"]} bytes')
+                for a in ALGORITHMS
+                if a in sizes
+            ],
+        }
+
+    for slug, ch in charts.items():
+        write(
+            os.path.join(OUT_DIR, f"{slug}.svg"),
+            svg_bar_chart(ch["title"], ch["unit"], ch["rows"]),
+        )
+
+    # --- shared report content -----------------------------------------------
+    intro = (
+        "Performance of CAT signing and verification across all supported "
+        "algorithms. Timing measured with Criterion; sizes captured directly "
+        "from signed tokens."
+    )
+    # (label, slug) pairs, in display order, for the graph sections.
+    graph_order = [
+        ("Signing time", "signing_time"),
+        ("Verification time", "verification_time"),
+        ("Signature size", "signature_size"),
+        ("Encoded token size", "token_size"),
+    ]
+    notes = [
+        "**HS256** is a symmetric MAC (COSE_Mac0): fastest and smallest, but "
+        "signer and verifier share the same secret.",
+        "**ES256** (ECDSA P-256) and **PS256** (RSASSA-PSS) are asymmetric "
+        "(COSE_Sign1): the verifier only needs the public key.",
+        "All tokens carry an identical claim set so sizes and times are "
+        "comparable across algorithms.",
+        "Regenerate with `cargo bench --bench cat && python3 scripts/bench_report.py`.",
+    ]
+    # Summary table rows: (algorithm, signing, verification, sig size, token size).
+    summary = []
+    for a in ALGORITHMS:
+        summary.append(
+            (
+                a,
+                fmt_time(sign[a]["mean_ns"]) if sign[a] else "—",
+                fmt_time(verify[a]["mean_ns"]) if verify[a] else "—",
+                f'{sizes[a]["signature_bytes"]} B' if a in sizes else "—",
+                f'{sizes[a]["token_bytes"]} B' if a in sizes else "—",
+            )
+        )
+
+    # --- markdown report -----------------------------------------------------
+    lines = [
+        "# Common Access Token — Benchmark Report",
+        "",
+        intro.replace("with Criterion", "with [Criterion]"),
+        "",
+        "[Criterion]: https://github.com/bheisler/criterion.rs",
+        "",
+        "## Summary",
+        "",
+        "| Algorithm | Signing time | Verification time | Signature size | Token size |",
+        "| --------- | -----------: | ----------------: | -------------: | ---------: |",
+    ]
+    lines += [f"| {r[0]} | {r[1]} | {r[2]} | {r[3]} | {r[4]} |" for r in summary]
+    lines += ["", "## Graphs", ""]
+    for label, slug in graph_order:
+        if slug in charts:
+            lines += [f"### {label}", "", f"![{label}]({slug}.svg)", ""]
+    lines += ["## Notes", ""]
+    lines += [f"- {n}" for n in notes]
+    lines.append("")
+    write(os.path.join(OUT_DIR, "report.md"), "\n".join(lines))
+
+    # --- optional PDF --------------------------------------------------------
+    if "--pdf" in sys.argv[1:]:
+        pdf_path = os.path.join(OUT_DIR, "report.pdf")
+        try:
+            render_pdf(pdf_path, intro, summary, graph_order, charts, notes)
+        except ImportError:
+            print(
+                "Could not render PDF: the `fpdf2` package is not installed.\n"
+                "Install it with `pip3 install fpdf2`, then re-run with --pdf.",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"wrote {os.path.relpath(pdf_path, ROOT)}")
+
+    return 0
+
+
+# --- PDF rendering (fpdf2) ---------------------------------------------------
+# fpdf2 is a pure-Python package (no native dependencies), so the PDF path works
+# anywhere `pip install fpdf2` succeeds — including CI without a browser. We draw
+# the bar charts directly from the same numbers used for the SVGs.
+
+# RGB equivalents of the SVG bar colors, keyed by algorithm.
+PDF_BAR_COLORS = {
+    "HS256": (78, 121, 167),
+    "ES256": (89, 161, 79),
+    "PS256": (225, 87, 89),
+}
+
+
+def render_pdf(
+    pdf_path: str,
+    intro: str,
+    summary: list[tuple],
+    graph_order: list[tuple[str, str]],
+    charts: dict[str, dict],
+    notes: list[str],
+) -> None:
+    """Render the report to PDF with fpdf2. Raises ImportError if unavailable."""
+    from fpdf import FPDF  # imported lazily so the PDF dep stays optional
+
+    pdf = FPDF(format="A4", unit="mm")
+    pdf.set_auto_page_break(auto=True, margin=18)
+    pdf.set_margins(18, 18, 18)
+    pdf.add_page()
+    epw = pdf.epw  # effective page width (inside margins)
+
+    # Title.
+    pdf.set_font("Helvetica", "B", 20)
+    pdf.multi_cell(epw, 9, "Common Access Token - Benchmark Report")
+    pdf.ln(2)
+    pdf.set_font("Helvetica", "", 11)
+    pdf.set_text_color(80)
+    pdf.multi_cell(epw, 5.5, _ascii(intro))
+    pdf.set_text_color(0)
+    pdf.ln(4)
+
+    # Summary table.
+    _pdf_heading(pdf, "Summary")
+    headers = [
+        "Algorithm",
+        "Signing time",
+        "Verification time",
+        "Signature size",
+        "Token size",
+    ]
+    widths = [epw * w for w in (0.20, 0.22, 0.24, 0.18, 0.16)]
+    pdf.set_font("Helvetica", "B", 10)
+    pdf.set_fill_color(245)
+    for head, w in zip(headers, widths):
+        pdf.cell(w, 8, head, border=1, align="C", fill=True)
+    pdf.ln()
+    pdf.set_font("Helvetica", "", 10)
+    for row in summary:
+        for i, (cell, w) in enumerate(zip(row, widths)):
+            pdf.cell(w, 7, _ascii(cell), border=1, align="L" if i == 0 else "R")
+        pdf.ln()
+    pdf.ln(4)
+
+    # Graphs.
+    _pdf_heading(pdf, "Graphs")
+    for label, slug in graph_order:
+        if slug in charts:
+            _pdf_bar_chart(pdf, charts[slug], epw)
+
+    # Notes.
+    _pdf_heading(pdf, "Notes")
+    pdf.set_font("Helvetica", "", 10)
+    for note in notes:
+        _pdf_note(pdf, note, epw)
+
+    pdf.output(pdf_path)
+
+
+def _pdf_heading(pdf, text: str) -> None:
+    pdf.set_font("Helvetica", "B", 14)
+    pdf.ln(2)
+    pdf.cell(0, 8, text, new_x="LMARGIN", new_y="NEXT")
+    pdf.ln(1)
+
+
+def _pdf_bar_chart(pdf, chart: dict, epw: float) -> None:
+    """Draw one horizontal bar chart at the current cursor position."""
+    rows = chart["rows"]
+    max_val = max((v for _, v, _ in rows), default=1.0) or 1.0
+    label_w = 22  # mm reserved for the algorithm label
+    value_w = 30  # mm reserved for the value text on the right
+    bar_max = epw - label_w - value_w
+    row_h = 9
+
+    # Keep the whole chart (title + bars) on one page.
+    needed = 14 + row_h * len(rows)
+    if pdf.get_y() + needed > pdf.page_break_trigger:
+        pdf.add_page()
+
+    pdf.set_font("Helvetica", "B", 11)
+    pdf.cell(0, 7, _ascii(chart["title"]), new_x="LMARGIN", new_y="NEXT")
+    pdf.set_font("Helvetica", "", 8)
+    pdf.set_text_color(120)
+    pdf.cell(0, 4, _ascii(f"lower is better - {chart['unit']}"),
+             new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(0)
+
+    x0 = pdf.l_margin
+    for label, value, display in rows:
+        y = pdf.get_y()
+        pdf.set_font("Helvetica", "B", 9)
+        pdf.set_xy(x0, y)
+        pdf.cell(label_w, row_h, _ascii(label), align="L")
+        bar_w = max(0.6, bar_max * (value / max_val))
+        r, g, b = PDF_BAR_COLORS.get(label, (136, 136, 136))
+        pdf.set_fill_color(r, g, b)
+        pdf.rect(x0 + label_w, y + 1.5, bar_w, row_h - 3, style="F")
+        pdf.set_font("Helvetica", "", 9)
+        pdf.set_xy(x0 + label_w + bar_w + 1.5, y)
+        pdf.cell(value_w, row_h, _ascii(display), align="L")
+        pdf.set_y(y + row_h)
+    pdf.ln(3)
+
+
+def _pdf_note(pdf, note: str, epw: float) -> None:
+    """Render one bullet note, honoring **bold** and `code` spans."""
+    pdf.cell(4, 5.5, "-")
+    x_start = pdf.get_x()
+    # Split into (text, is_bold, is_code) runs.
+    for text, bold, code in _md_runs(note):
+        style = "B" if bold else ""
+        pdf.set_font("Courier" if code else "Helvetica", style, 10)
+        pdf.write(5.5, _ascii(text))
+    pdf.ln(6)
+    pdf.set_x(x_start - 4)
+
+
+def _md_runs(text: str):
+    """Yield (text, is_bold, is_code) runs from a tiny markdown subset."""
+    # Code spans first (they win over bold), then bold within non-code parts.
+    for i, code_part in enumerate(text.split("`")):
+        if i % 2:  # inside backticks
+            yield (code_part, False, True)
+        else:
+            for j, bold_part in enumerate(code_part.split("**")):
+                if bold_part:
+                    yield (bold_part, bool(j % 2), False)
+
+
+def _ascii(text: str) -> str:
+    """Map the few non-ASCII glyphs we use to ASCII for the core PDF fonts.
+
+    fpdf2's built-in fonts are latin-1 only; the report uses an em dash and a
+    micro sign, so substitute readable ASCII rather than ship a font file.
+    """
+    return (
+        text.replace("—", "-")  # em dash
+        .replace("µ", "u")  # micro sign (µs -> us)
+        .replace("…", "...")
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run the Common Access Token benchmarks and generate a report with graphs.
+# Outputs land in target/bench/ (report.md, *.svg, and report.pdf with --pdf).
+#
+# Usage:
+#   scripts/run_benchmarks.sh            # full Criterion run (most accurate)
+#   scripts/run_benchmarks.sh --quick    # short run for a fast sanity check
+#   scripts/run_benchmarks.sh --pdf      # also render report.pdf (uses .venv + fpdf2)
+#   scripts/run_benchmarks.sh --quick --pdf
+#
+# The markdown report and SVG charts use the system `python3` (no extra deps).
+# The PDF needs `fpdf2`; since Homebrew's Python is externally managed (PEP 668),
+# --pdf bootstraps a local virtualenv at .venv and installs fpdf2 there.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VENV_DIR=".venv"
+
+BENCH_ARGS=()
+REPORT_ARGS=()
+WANT_PDF=0
+for arg in "$@"; do
+  case "$arg" in
+    --quick)
+      # Shorter sampling for a quick look; less statistically robust.
+      BENCH_ARGS=(-- --warm-up-time 0.5 --measurement-time 2 --sample-size 30)
+      ;;
+    --pdf)
+      REPORT_ARGS+=(--pdf)
+      WANT_PDF=1
+      ;;
+    *)
+      echo "unknown option: $arg" >&2
+      echo "usage: $0 [--quick] [--pdf]" >&2
+      exit 64
+      ;;
+  esac
+done
+
+# Default to the system interpreter; switch to the venv's when a PDF is wanted.
+PY="python3"
+if [[ "$WANT_PDF" -eq 1 ]]; then
+  if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    echo "==> Creating virtualenv ($VENV_DIR) for PDF rendering"
+    python3 -m venv "$VENV_DIR"
+  fi
+  # Install fpdf2 only if it isn't already present in the venv.
+  if ! "$VENV_DIR/bin/python" -c "import fpdf" >/dev/null 2>&1; then
+    echo "==> Installing fpdf2 into $VENV_DIR"
+    "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+    "$VENV_DIR/bin/pip" install --quiet fpdf2
+  fi
+  PY="$VENV_DIR/bin/python"
+fi
+
+echo "==> Running benchmarks (cargo bench --bench cat)"
+# Note the `+"..."` guard: on macOS's Bash 3.2, expanding an empty array under
+# `set -u` errors with "unbound variable", so only expand when non-empty.
+cargo bench --bench cat ${BENCH_ARGS[@]+"${BENCH_ARGS[@]}"}
+
+echo "==> Generating report and graphs"
+"$PY" scripts/bench_report.py ${REPORT_ARGS[@]+"${REPORT_ARGS[@]}"}
+
+echo "==> Done. See target/bench/report.md"


### PR DESCRIPTION
## Summary

Adds benchmarks for Common Access Token performance across all supported algorithms (HS256, ES256, PS256), plus tooling to turn the results into a shareable report with graphs.

Measures, for both signing and verifying:
- **Signature size** (raw tag/signature) and full encoded token size
- **Signing time**
- **Verification time**

## What's included

- **`benches/cat.rs`** — [Criterion](https://github.com/bheisler/criterion.rs) benchmarks runnable the native Rust way with `cargo bench --bench cat`. Emits timing data to `target/criterion/` and size data to `target/bench/sizes.json`.
- **`scripts/bench_report.py`** — generates a markdown report (`report.md`) and SVG bar charts with **no third-party dependencies**. With `--pdf` it also renders `report.pdf` via [`fpdf2`](https://pypi.org/project/fpdf2/) (pure Python, no native libs, no browser).
- **`scripts/run_benchmarks.sh`** — runs the benchmarks and report in one step. `--quick` for a fast run; `--pdf` bootstraps a local `.venv` with `fpdf2` automatically.
- README documentation and `.gitignore` entries for `.venv`/`.DS_Store`.

## Indicative results (Apple Silicon, release build)

| Algorithm | Signing | Verification | Signature | Token |
| --- | ---: | ---: | ---: | ---: |
| HS256 | ~1.8 µs | ~3.4 µs | 32 B | 150 B |
| ES256 | ~350 µs | ~220 µs | 64 B | 182 B |
| PS256 | ~1.16 ms | ~140 µs | 256 B | 376 B |

## CI

The markdown/SVG report needs no extra packages. For the PDF in CI (no browser needed):

\`\`\`yaml
- run: cargo bench --bench cat
- run: pip3 install fpdf2 && python3 scripts/bench_report.py --pdf
\`\`\`

## Test plan

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, `cargo test` (73 passed) all pass.
- Ran `cargo bench --bench cat` and verified `report.md`, all four SVGs, and `report.pdf` generate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)